### PR TITLE
adding tar value

### DIFF
--- a/shepher-packaging/pom.xml
+++ b/shepher-packaging/pom.xml
@@ -55,6 +55,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
+	      <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>src/main/assembly/bin.xml</descriptor>
                 <descriptor>src/main/assembly/src.xml</descriptor>


### PR DESCRIPTION
with default value of tarLongFileMode for maven-assembly-plugin, this is known issue. should use 'posix' for the tarLongFileMode so that it works for bigger uid.