### PR TITLE
support ldap OU config

### DIFF
--- a/conf/application-default.properties
+++ b/conf/application-default.properties
@@ -12,6 +12,7 @@ cas.logout.url=${cas.server.url.prefix}/logout
 ldap.url=ldap://ldap.example.com:389/dc=example,dc=com
 ldap.password=123456
 ldap.dn=cn=admin,dc=example,dc=com
+ldap.allow.ou=
 
 # DEMO LOGIN
 demo.admin.name=youradmin


### PR DESCRIPTION
原ldap登录方式只能匹配 uid=xxx,ou=people,ou=people 的用户，不具有通用性，修改后允许的 ou 分组即可通过 ldap.allow.ou 设置